### PR TITLE
Fix sequential GCS read file offset advancement

### DIFF
--- a/src/gcs_filesystem.cpp
+++ b/src/gcs_filesystem.cpp
@@ -347,7 +347,6 @@ int64_t GCSFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) 
 
 	nr_bytes = MinValue<int64_t>(max_read, nr_bytes);
 	Read(handle, buffer, nr_bytes, gcp_handle.file_offset);
-	gcp_handle.file_offset += nr_bytes;
 	return nr_bytes;
 }
 

--- a/test/cpp/test_file_operations.cpp
+++ b/test/cpp/test_file_operations.cpp
@@ -4,8 +4,32 @@
 #include <thread>
 #include <vector>
 #include <atomic>
+#include <cstring>
 
 using namespace duckdb;
+
+namespace {
+
+class TestGCSFileSystem : public GCSFileSystem {
+public:
+	TestGCSFileSystem() : GCSFileSystem("") {
+	}
+
+	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
+		auto &gcs_handle = handle.Cast<GCSFileHandle>();
+		memset(buffer, 'x', UnsafeNumericCast<size_t>(nr_bytes));
+		gcs_handle.file_offset = location + UnsafeNumericCast<idx_t>(nr_bytes);
+	}
+};
+
+static shared_ptr<GCSContextState> CreateTestContext() {
+	GCSReadOptions options;
+	auto credentials = google::cloud::MakeInsecureCredentials();
+	auto client = gcs::Client(google::cloud::Options {}.set<google::cloud::UnifiedCredentialsOption>(credentials));
+	return make_shared_ptr<GCSContextState>(client, options);
+}
+
+} // namespace
 
 TEST_CASE("SafeMaxRead: Integer overflow protection", "[gcs][file]") {
 	SECTION("Normal case - offset < length") {
@@ -65,6 +89,24 @@ TEST_CASE("SafeMaxRead: Integer overflow protection", "[gcs][file]") {
 		int64_t result = SafeMaxRead(offset, length);
 		REQUIRE(result == 100);
 	}
+}
+
+TEST_CASE("GCSFileSystem: sequential reads advance file offset once", "[gcs][file]") {
+	TestGCSFileSystem fs;
+	GCSReadOptions options;
+	auto context = CreateTestContext();
+	OpenFileInfo info("gs://test-bucket/test-object");
+	GCSFileHandle handle(fs, info, FileFlags::FILE_FLAGS_READ, options, "test-bucket", "test-object", context);
+	handle.length = 1000;
+
+	char buffer[100];
+	auto bytes_read = fs.GCSFileSystem::Read(handle, buffer, sizeof(buffer));
+	REQUIRE(bytes_read == 100);
+	REQUIRE(handle.file_offset == 100);
+
+	bytes_read = fs.GCSFileSystem::Read(handle, buffer, sizeof(buffer));
+	REQUIRE(bytes_read == 100);
+	REQUIRE(handle.file_offset == 200);
 }
 
 TEST_CASE("GCSFileHandle: Parallel reads", "[gcs][file][parallel]") {


### PR DESCRIPTION
## Summary

- remove the extra `file_offset` increment from the non-positional GCS read wrapper
- add a focused unit test for sequential reads advancing the offset once

Closes #25

## Testing

- `./build/release/extension/gcs/test/cpp/gcs_unit_tests`
- Loaded the locally built GCS extension with DuckDB v1.5.1 and verified DuckDB Iceberg can bind a real `gcss://...metadata.json` Iceberg scan with `LIMIT 0`.