### PR TITLE
Add directory write support for partitioned (Hive) COPY

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ---
 
-This DuckDB extension allows you to read files from Google Cloud Storage,
-natively, using the Google Cloud C++ SDK.
+This DuckDB extension allows you to read and write files on Google Cloud
+Storage, natively, using the Google Cloud C++ SDK.
 
 DuckDB's core httpfs extension allows reading files from GCS, but it does so
 using the S3 compatibility API. This is not as fast as the native API and it
@@ -13,6 +13,28 @@ policy for service accounts.
 Note: Because the core `httpfs` extension registers itself as a handler for
 `gs://` and `gcs://` URLs, this extension also supports `gcss://` as a way to
 force its usage.
+
+## Writing
+
+In addition to reading, the extension supports writing single files as well as
+directories, so a `COPY ... TO` statement can target a `gs://` path the same way
+it would a local one. This includes partitioned (Hive) writes, where each
+partition is written to its own `key=value/` prefix:
+
+```sql
+-- Write a single file
+COPY tbl TO 'gs://my-bucket/path/data.parquet' (FORMAT parquet);
+
+-- Write a Hive-partitioned dataset (one directory/prefix per partition value)
+COPY tbl TO 'gs://my-bucket/path/dataset' (FORMAT parquet, PARTITION_BY (year, month));
+
+-- Re-running with OVERWRITE clears the existing files in the target directory first
+COPY tbl TO 'gs://my-bucket/path/dataset' (FORMAT parquet, PARTITION_BY (year, month), OVERWRITE);
+```
+
+Since GCS has no real directories, a "directory" is just a shared object-key
+prefix: it is created implicitly when objects are written and is considered to
+exist when at least one object shares its prefix.
 
 ## Building
 

--- a/src/gcs_filesystem.cpp
+++ b/src/gcs_filesystem.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/catalog/catalog_transaction.hpp"
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "gcs_secret.hpp"
 
 #include <atomic>
@@ -16,6 +17,7 @@
 #include <future>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <thread>
 
 namespace duckdb {
@@ -150,6 +152,18 @@ void GCSContextState::InvalidateCachedMetadata(const std::string &bucket, const 
 	auto key = MakeMetadataKey(bucket, object_key);
 	std::scoped_lock lock(cache_mutex);
 	metadata_cache.erase(key);
+}
+
+void GCSContextState::InvalidateCachedList(const std::string &bucket) {
+	auto key_prefix = MakeListKey(bucket, "");
+	std::scoped_lock lock(cache_mutex);
+	for (auto it = list_cache.begin(); it != list_cache.end();) {
+		if (it->first.rfind(key_prefix, 0) == 0) {
+			it = list_cache.erase(it);
+		} else {
+			++it;
+		}
+	}
 }
 
 void GCSContextState::EvictLRUMetadataEntryLocked() {
@@ -371,7 +385,8 @@ idx_t GCSFileSystem::SeekPosition(FileHandle &handle) {
 }
 
 void GCSFileSystem::FileSync(FileHandle &handle) {
-	// No-op for read-only filesystem
+	// No-op: GCS writes are buffered into a resumable upload that is finalized on Close(), so there is
+	// no intermediate flush to perform here.
 }
 
 bool GCSFileSystem::LoadFileInfo(GCSFileHandle &handle) {
@@ -827,6 +842,284 @@ int64_t GCSFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes)
 	auto &gsfh = handle.Cast<GCSFileHandle>();
 	auto write_buffer = char_ptr_cast(buffer);
 	return gsfh.WriteInto(write_buffer, nr_bytes);
+}
+
+// Translate a failed GCS list/probe status into a descriptive IOException. Mirrors the error handling
+// in Glob() so that a listing failure surfaces loudly instead of being mistaken for an empty/absent
+// directory. The latter would let a partitioned OVERWRITE skip its cleanup and silently mix old and
+// new data.
+static void ThrowGCSListError(const google::cloud::Status &status, const std::string &bucket, const std::string &path) {
+	switch (status.code()) {
+	case google::cloud::StatusCode::kUnauthenticated:
+		throw IOException("GCS Authentication failed. Please run: gcloud auth application-default login");
+	case google::cloud::StatusCode::kPermissionDenied:
+		throw IOException("GCS Permission denied. Check bucket permissions for: " + bucket);
+	case google::cloud::StatusCode::kNotFound:
+		throw IOException("GCS bucket not found: " + bucket);
+	default:
+		throw IOException("Failed to list GCS objects under '" + path + "': " + status.message());
+	}
+}
+
+// Turn a parsed object key into a directory prefix (ending in '/'). GCSParsedUrl already strips
+// trailing slashes, so an empty key denotes the bucket root.
+std::string GCSDirectoryPrefix(const std::string &object_key) {
+	if (object_key.empty()) {
+		return "";
+	}
+	if (object_key.back() == '/') {
+		return object_key;
+	}
+	return object_key + "/";
+}
+
+bool GCSFileSystem::DirectoryExists(const string &directory, optional_ptr<FileOpener> opener) {
+	GCSParsedUrl parsed_url;
+	parsed_url.ParseUrl(directory);
+
+	auto context = GetOrCreateStorageContext(opener, directory, parsed_url);
+	if (!context) {
+		return false;
+	}
+	auto &gcs_context = context->As<GCSContextState>();
+
+	auto prefix = GCSDirectoryPrefix(parsed_url.object_key);
+	// The bucket root is always considered to exist as a directory.
+	if (prefix.empty()) {
+		return true;
+	}
+
+	// GCS has no directories; a directory "exists" if at least one object shares its prefix. A listing
+	// failure must throw rather than report "absent": COPY gates its OVERWRITE cleanup on this result,
+	// so a swallowed error would let a populated directory be treated as new and mix stale + fresh data.
+	auto list = gcs_context.GetClient().ListObjects(parsed_url.bucket, gcs::Prefix(prefix), gcs::MaxResults(1));
+	for (auto &&object_metadata : list) {
+		if (!object_metadata) {
+			ThrowGCSListError(object_metadata.status(), parsed_url.bucket, directory);
+		}
+		return true;
+	}
+	// The range completed cleanly with no objects under the prefix: the directory is genuinely absent.
+	return false;
+}
+
+void GCSFileSystem::CreateDirectory(const string &directory, optional_ptr<FileOpener> opener) {
+	// No-op: GCS creates the enclosing "directory" prefix implicitly when an object is written.
+	// We still validate the URL so malformed paths fail early, matching local filesystem behavior.
+	GCSParsedUrl parsed_url;
+	parsed_url.ParseUrl(directory);
+}
+
+void GCSFileSystem::CreateDirectoriesRecursive(const string &path, optional_ptr<FileOpener> opener) {
+	// Directories are implicit in object storage, so there is nothing to create. We override the
+	// base implementation, which walks parent paths via Path::FromString - that does not understand
+	// gs:// URLs and would issue unnecessary DirectoryExists calls.
+	GCSParsedUrl parsed_url;
+	parsed_url.ParseUrl(path);
+}
+
+bool GCSFileSystem::ListFilesExtended(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
+                                      optional_ptr<FileOpener> opener) {
+	GCSParsedUrl parsed_url;
+	parsed_url.ParseUrl(directory);
+
+	auto context = GetOrCreateStorageContext(opener, directory, parsed_url);
+	if (!context) {
+		return false;
+	}
+	auto &gcs_context = context->As<GCSContextState>();
+
+	auto prefix = GCSDirectoryPrefix(parsed_url.object_key);
+
+	// A delimiter-based listing returns the immediate children of the prefix: objects become files
+	// and common prefixes become subdirectories. This mirrors the local filesystem, which reports
+	// the entries directly contained in a directory (relative names, not full paths).
+	auto list =
+	    gcs_context.GetClient().ListObjectsAndPrefixes(parsed_url.bucket, gcs::Prefix(prefix), gcs::Delimiter("/"));
+	for (auto &&item : list) {
+		if (!item) {
+			// Throw on a mid-pagination failure: callbacks for earlier pages have already fired, so
+			// returning here would silently yield a partial listing. CheckDirectory ignores the bool
+			// return, and a partial list would leave stale files behind during an OVERWRITE.
+			ThrowGCSListError(item.status(), parsed_url.bucket, directory);
+		}
+		if (absl::holds_alternative<gcs::ObjectMetadata>(*item)) {
+			const auto &object_metadata = absl::get<gcs::ObjectMetadata>(*item);
+			const auto &name = object_metadata.name();
+			// Skip a directory placeholder object whose name is exactly the prefix.
+			if (name.size() <= prefix.size()) {
+				continue;
+			}
+			OpenFileInfo info(name.substr(prefix.size()));
+			info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+			info.extended_info->options["type"] = Value("file");
+			info.extended_info->options["file_size"] =
+			    Value::BIGINT(UnsafeNumericCast<int64_t>(object_metadata.size()));
+			callback(info);
+		} else {
+			// A common prefix, e.g. "data/part=1/", is a subdirectory.
+			std::string sub_prefix = absl::get<std::string>(*item);
+			while (!sub_prefix.empty() && sub_prefix.back() == '/') {
+				sub_prefix.pop_back();
+			}
+			if (sub_prefix.size() <= prefix.size()) {
+				continue;
+			}
+			OpenFileInfo info(sub_prefix.substr(prefix.size()));
+			info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+			info.extended_info->options["type"] = Value("directory");
+			callback(info);
+		}
+	}
+	return true;
+}
+
+void GCSFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
+	GCSParsedUrl parsed_url;
+	parsed_url.ParseUrl(filename);
+
+	auto context = GetOrCreateStorageContext(opener, filename, parsed_url);
+	if (!context) {
+		throw IOException("Failed to create GCS context for removing file: " + filename);
+	}
+	auto &gcs_context = context->As<GCSContextState>();
+
+	auto status = gcs_context.GetClient().DeleteObject(parsed_url.bucket, parsed_url.object_key);
+	if (!status.ok()) {
+		throw IOException("Failed to delete GCS object '" + filename + "': " + status.message());
+	}
+	gcs_context.InvalidateCachedMetadata(parsed_url.bucket, parsed_url.object_key);
+	gcs_context.InvalidateCachedList(parsed_url.bucket);
+}
+
+bool GCSFileSystem::TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
+	GCSParsedUrl parsed_url;
+	parsed_url.ParseUrl(filename);
+
+	auto context = GetOrCreateStorageContext(opener, filename, parsed_url);
+	if (!context) {
+		return false;
+	}
+	auto &gcs_context = context->As<GCSContextState>();
+
+	auto status = gcs_context.GetClient().DeleteObject(parsed_url.bucket, parsed_url.object_key);
+	if (!status.ok()) {
+		if (status.code() == google::cloud::StatusCode::kNotFound) {
+			return false;
+		}
+		throw IOException("Failed to delete GCS object '" + filename + "': " + status.message());
+	}
+	gcs_context.InvalidateCachedMetadata(parsed_url.bucket, parsed_url.object_key);
+	gcs_context.InvalidateCachedList(parsed_url.bucket);
+	return true;
+}
+
+void GCSFileSystem::RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener) {
+	// Like the base implementation this best-effort deletes each file (missing files are ignored), but
+	// it invalidates each affected bucket's list cache only once at the end instead of once per file
+	// (the base loops TryRemoveFile, each of which would rescan the whole list cache). This matters for
+	// OVERWRITE, which removes every existing file in a directory in one call.
+	std::set<std::string> touched_buckets;
+	std::unordered_map<std::string, shared_ptr<GCSContextState>> bucket_contexts;
+	for (const auto &filename : filenames) {
+		GCSParsedUrl parsed_url;
+		parsed_url.ParseUrl(filename);
+
+		auto context = GetOrCreateStorageContext(opener, filename, parsed_url);
+		if (!context) {
+			continue;
+		}
+		auto &gcs_context = context->As<GCSContextState>();
+
+		auto status = gcs_context.GetClient().DeleteObject(parsed_url.bucket, parsed_url.object_key);
+		if (!status.ok() && status.code() != google::cloud::StatusCode::kNotFound) {
+			throw IOException("Failed to delete GCS object '" + filename + "': " + status.message());
+		}
+		gcs_context.InvalidateCachedMetadata(parsed_url.bucket, parsed_url.object_key);
+		touched_buckets.insert(parsed_url.bucket);
+		bucket_contexts.emplace(parsed_url.bucket, context);
+	}
+
+	for (const auto &bucket : touched_buckets) {
+		bucket_contexts[bucket]->As<GCSContextState>().InvalidateCachedList(bucket);
+	}
+}
+
+void GCSFileSystem::RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener) {
+	GCSParsedUrl parsed_url;
+	parsed_url.ParseUrl(directory);
+
+	auto context = GetOrCreateStorageContext(opener, directory, parsed_url);
+	if (!context) {
+		throw IOException("Failed to create GCS context for removing directory: " + directory);
+	}
+	auto &gcs_context = context->As<GCSContextState>();
+
+	auto prefix = GCSDirectoryPrefix(parsed_url.object_key);
+	auto client = gcs_context.GetClient();
+
+	// Recursively delete every object under the prefix (no delimiter -> all descendants).
+	auto list = client.ListObjects(parsed_url.bucket, gcs::Prefix(prefix));
+	for (auto &&object_metadata : list) {
+		if (!object_metadata) {
+			ThrowGCSListError(object_metadata.status(), parsed_url.bucket, directory);
+		}
+		auto status = client.DeleteObject(parsed_url.bucket, object_metadata->name());
+		if (!status.ok() && status.code() != google::cloud::StatusCode::kNotFound) {
+			throw IOException("Failed to delete GCS object '" + object_metadata->name() + "': " + status.message());
+		}
+		gcs_context.InvalidateCachedMetadata(parsed_url.bucket, object_metadata->name());
+	}
+	gcs_context.InvalidateCachedList(parsed_url.bucket);
+}
+
+void GCSFileSystem::MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener) {
+	GCSParsedUrl source_url;
+	source_url.ParseUrl(source);
+	GCSParsedUrl target_url;
+	target_url.ParseUrl(target);
+
+	auto context = GetOrCreateStorageContext(opener, source, source_url);
+	if (!context) {
+		throw IOException("Failed to create GCS context for moving file: " + source);
+	}
+	auto &gcs_context = context->As<GCSContextState>();
+	auto client = gcs_context.GetClient();
+
+	std::optional<gcs::ObjectMetadata> result_metadata;
+
+	// Within a single bucket, prefer the native server-side move (the Objects: move RPC). On
+	// Hierarchical-Namespace buckets this is a metadata-only atomic rename; on flat buckets GCS still
+	// performs the move server-side in a single call. MoveObject cannot move across buckets, so for a
+	// cross-bucket move, or if the move RPC is ever unavailable, we fall back to a server-side copy +
+	// delete below, which works on any bucket but is not atomic (a failed delete can leave the source).
+	if (source_url.bucket == target_url.bucket) {
+		auto moved = client.MoveObject(source_url.bucket, source_url.object_key, target_url.object_key);
+		if (moved) {
+			result_metadata = std::move(*moved);
+		}
+	}
+
+	if (!result_metadata.has_value()) {
+		auto rewritten = client.RewriteObjectBlocking(source_url.bucket, source_url.object_key, target_url.bucket,
+		                                              target_url.object_key);
+		if (!rewritten) {
+			throw IOException("Failed to move GCS object from '" + source + "' to '" + target +
+			                  "': " + rewritten.status().message());
+		}
+		auto status = client.DeleteObject(source_url.bucket, source_url.object_key);
+		if (!status.ok() && status.code() != google::cloud::StatusCode::kNotFound) {
+			throw IOException("Failed to delete source GCS object '" + source + "' after move: " + status.message());
+		}
+		result_metadata = std::move(*rewritten);
+	}
+
+	gcs_context.InvalidateCachedMetadata(source_url.bucket, source_url.object_key);
+	gcs_context.SetCachedMetadata(target_url.bucket, target_url.object_key, *result_metadata);
+	gcs_context.InvalidateCachedList(source_url.bucket);
+	if (target_url.bucket != source_url.bucket) {
+		gcs_context.InvalidateCachedList(target_url.bucket);
+	}
 }
 
 } // namespace duckdb

--- a/src/gcs_filesystem.cpp
+++ b/src/gcs_filesystem.cpp
@@ -54,6 +54,26 @@ gcs::Client BuildOptimizedClient(std::shared_ptr<google::cloud::Credentials> cre
 	return gcs::Client(options);
 }
 
+static std::string NoCredentialsErrorMessage() {
+	std::string error_msg = "No valid GCP credentials found.\n\n";
+	error_msg += "The Google Cloud Storage extension requires authentication.\n";
+	error_msg += "Please use one of these methods:\n\n";
+	error_msg += "1. Set up Application Default Credentials:\n";
+	error_msg += "   gcloud auth application-default login\n\n";
+	error_msg += "   Note: Regular 'gcloud auth login' is NOT sufficient.\n";
+	error_msg += "   You must use 'gcloud auth application-default login'.\n\n";
+	error_msg += "2. Use a service account key file:\n";
+	error_msg += "   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json\n\n";
+	error_msg += "3. Run in a GCP environment with default service account\n\n";
+	error_msg += "4. Create a secret in secret manager, one of:\n";
+	error_msg += "   duckdb> CREATE SECRET gcp (TYPE gcp, PROVIDER credential_chain);\n";
+	error_msg += "   duckdb> CREATE SECRET gcp (TYPE gcp, PROVIDER service_account, service_account_key_path = "
+	             "'/path/to/key.json');\n";
+	error_msg +=
+	    "   duckdb> CREATE SECRET gcp (TYPE gcp, PROVIDER access_token, access_token = 'your_access_token');\n\n";
+	return error_msg;
+}
+
 void GCSContextState::QueryEnd() {
 }
 
@@ -515,7 +535,7 @@ vector<OpenFileInfo> GCSFileSystem::Glob(const string &path, FileOpener *opener)
 				auto &status = object_metadata.status();
 
 				if (status.code() == google::cloud::StatusCode::kUnauthenticated) {
-					throw IOException("GCS Authentication failed. Please run: gcloud auth application-default login");
+					throw IOException(NoCredentialsErrorMessage());
 				} else if (status.code() == google::cloud::StatusCode::kPermissionDenied) {
 					throw IOException("GCS Permission denied. Check bucket permissions for: " + parsed_url.bucket);
 				} else if (status.code() == google::cloud::StatusCode::kNotFound) {
@@ -777,24 +797,7 @@ shared_ptr<GCSContextState> GCSFileSystem::CreateStorageContext(optional_ptr<Fil
 	}
 
 	// Provide helpful error message
-	std::string error_msg = "No valid GCP credentials found.\n\n";
-	error_msg += "The Google Cloud Storage extension requires authentication.\n";
-	error_msg += "Please use one of these methods:\n\n";
-	error_msg += "1. Set up Application Default Credentials:\n";
-	error_msg += "   gcloud auth application-default login\n\n";
-	error_msg += "   Note: Regular 'gcloud auth login' is NOT sufficient.\n";
-	error_msg += "   You must use 'gcloud auth application-default login'.\n\n";
-	error_msg += "2. Use a service account key file:\n";
-	error_msg += "   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json\n\n";
-	error_msg += "3. Run in a GCP environment with default service account\n\n";
-	error_msg += "4. Create a secret in secret manager, one of:\n";
-	error_msg += "   duckdb> CREATE SECRET gcp (TYPE gcp, PROVIDER credential_chain);\n";
-	error_msg += "   duckdb> CREATE SECRET gcp (TYPE gcp, PROVIDER service_account, service_account_key_path = "
-	             "'/path/to/key.json');\n";
-	error_msg +=
-	    "   duckdb> CREATE SECRET gcp (TYPE gcp, PROVIDER access_token, access_token = 'your_access_token');\n\n";
-
-	throw IOException(error_msg);
+	throw IOException(NoCredentialsErrorMessage());
 }
 
 void GCSFileSystem::LoadRemoteFileInfo(GCSFileHandle &handle) {
@@ -851,7 +854,7 @@ int64_t GCSFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes)
 static void ThrowGCSListError(const google::cloud::Status &status, const std::string &bucket, const std::string &path) {
 	switch (status.code()) {
 	case google::cloud::StatusCode::kUnauthenticated:
-		throw IOException("GCS Authentication failed. Please run: gcloud auth application-default login");
+		throw IOException(NoCredentialsErrorMessage());
 	case google::cloud::StatusCode::kPermissionDenied:
 		throw IOException("GCS Permission denied. Check bucket permissions for: " + bucket);
 	case google::cloud::StatusCode::kNotFound:

--- a/src/include/gcs_filesystem.hpp
+++ b/src/include/gcs_filesystem.hpp
@@ -69,6 +69,9 @@ public:
 	void InvalidateCachedMetadata(const std::string &bucket, const std::string &object_key);
 	std::optional<vector<OpenFileInfo>> GetCachedList(const std::string &bucket, const std::string &prefix);
 	void SetCachedList(const std::string &bucket, const std::string &prefix, const vector<OpenFileInfo> &results);
+	// Drop all cached listings for a bucket. Called after writes/deletes so that subsequent globs
+	// observe the mutated set of objects instead of a stale cached listing.
+	void InvalidateCachedList(const std::string &bucket);
 
 	inline std::string MakeMetadataKey(const std::string &bucket, const std::string &object_key) {
 		return "metadata:" + bucket + ":" + object_key;
@@ -125,6 +128,10 @@ public:
 				// use the correct generation instead of a stale one.
 				context->SetCachedMetadata(bucket, object_key, *metadata);
 			}
+			// A newly written object may not be reflected in a cached listing, so drop the
+			// bucket's list cache to keep subsequent globs (e.g. reading back a partitioned
+			// dataset) consistent with what was just written.
+			context->InvalidateCachedList(bucket);
 			write_stream = nullptr;
 		}
 	}
@@ -214,11 +221,30 @@ public:
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 
+	// Directory and file write operations. GCS has no real directories; a "directory" is just a
+	// shared object-key prefix. These are required so DuckDB can write to a directory target, most
+	// notably partitioned (Hive) COPY writes, on par with the local filesystem.
+	bool DirectoryExists(const string &directory, optional_ptr<FileOpener> opener = nullptr) override;
+	void CreateDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override;
+	void CreateDirectoriesRecursive(const string &path, optional_ptr<FileOpener> opener = nullptr) override;
+	void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override;
+	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
+	bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
+	void RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener = nullptr) override;
+	void MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener = nullptr) override;
+
 protected:
 	unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &info, FileOpenFlags flags,
 	                                        optional_ptr<FileOpener> opener) override;
 
 	bool SupportsOpenFileExtended() const override {
+		return true;
+	}
+
+	bool ListFilesExtended(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
+	                       optional_ptr<FileOpener> opener) override;
+
+	bool SupportsListFilesExtended() const override {
 		return true;
 	}
 
@@ -244,5 +270,10 @@ private:
 
 // Helper function to safely calculate max read size, preventing integer overflow
 int64_t SafeMaxRead(idx_t offset, idx_t length);
+
+// Convert a parsed object key into a directory prefix (a key ending in '/', or the empty string for
+// the bucket root). Used to translate directory paths into GCS object-key prefixes for listing,
+// existence checks and recursive deletes.
+std::string GCSDirectoryPrefix(const std::string &object_key);
 
 } // namespace duckdb

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -8,11 +8,8 @@ find_package(google_cloud_cpp_storage REQUIRED)
 
 # Collect test source files
 set(TEST_SOURCES
-    test_main.cpp
-    test_cache_behavior.cpp
-    test_file_operations.cpp
-    test_glob_operations.cpp
-    test_generation_pinning.cpp
+    test_main.cpp test_cache_behavior.cpp test_file_operations.cpp
+    test_glob_operations.cpp test_generation_pinning.cpp
     test_directory_operations.cpp)
 
 # Add benchmarks only on Clang/GNU

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -7,8 +7,13 @@ set(TEST_TARGET gcs_unit_tests)
 find_package(google_cloud_cpp_storage REQUIRED)
 
 # Collect test source files
-set(TEST_SOURCES test_main.cpp test_cache_behavior.cpp test_file_operations.cpp
-                 test_glob_operations.cpp test_generation_pinning.cpp)
+set(TEST_SOURCES
+    test_main.cpp
+    test_cache_behavior.cpp
+    test_file_operations.cpp
+    test_glob_operations.cpp
+    test_generation_pinning.cpp
+    test_directory_operations.cpp)
 
 # Add benchmarks only on Clang/GNU
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")

--- a/test/cpp/test_directory_operations.cpp
+++ b/test/cpp/test_directory_operations.cpp
@@ -1,0 +1,103 @@
+#include "catch.hpp"
+#include "gcs_filesystem.hpp"
+#include "gcs_parsed_url.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+static shared_ptr<GCSContextState> CreateTestContext() {
+	GCSReadOptions options;
+	options.enable_caches = true;
+	auto credentials = google::cloud::MakeInsecureCredentials();
+	auto client = gcs::Client(google::cloud::Options {}.set<google::cloud::UnifiedCredentialsOption>(credentials));
+	return make_shared_ptr<GCSContextState>(client, options);
+}
+
+} // namespace
+
+TEST_CASE("GCSDirectoryPrefix: object key to directory prefix", "[gcs][directory]") {
+	SECTION("Empty key maps to bucket root") {
+		REQUIRE(GCSDirectoryPrefix("") == "");
+	}
+
+	SECTION("Simple key gets a trailing slash") {
+		REQUIRE(GCSDirectoryPrefix("data") == "data/");
+	}
+
+	SECTION("Nested key gets a trailing slash") {
+		REQUIRE(GCSDirectoryPrefix("a/b/c") == "a/b/c/");
+	}
+
+	SECTION("Key that already ends in slash is left unchanged") {
+		REQUIRE(GCSDirectoryPrefix("data/") == "data/");
+	}
+
+	SECTION("Hive-style partition key") {
+		REQUIRE(GCSDirectoryPrefix("out/year=2024/month=01") == "out/year=2024/month=01/");
+	}
+}
+
+TEST_CASE("GCSDirectoryPrefix: matches GCSParsedUrl normalization", "[gcs][directory]") {
+	// GCSParsedUrl strips trailing slashes from the object key, so the directory prefix derived from
+	// "gs://bucket/out" and "gs://bucket/out/" must be identical.
+	GCSParsedUrl without_slash;
+	without_slash.ParseUrl("gs://bucket/out");
+	GCSParsedUrl with_slash;
+	with_slash.ParseUrl("gs://bucket/out/");
+
+	REQUIRE(GCSDirectoryPrefix(without_slash.object_key) == "out/");
+	REQUIRE(GCSDirectoryPrefix(with_slash.object_key) == "out/");
+	REQUIRE(GCSDirectoryPrefix(without_slash.object_key) == GCSDirectoryPrefix(with_slash.object_key));
+}
+
+TEST_CASE("GCSContextState: InvalidateCachedList drops only the target bucket", "[gcs][directory][cache]") {
+	auto context = CreateTestContext();
+
+	vector<OpenFileInfo> results;
+	results.push_back(OpenFileInfo("gs://bucket-a/data/file.parquet"));
+
+	// Populate several listings across two buckets.
+	context->SetCachedList("bucket-a", "data/", results);
+	context->SetCachedList("bucket-a", "data/year=2024/", results);
+	context->SetCachedList("bucket-a", "other/", results);
+	context->SetCachedList("bucket-b", "data/", results);
+
+	// Sanity check that everything is cached.
+	REQUIRE(context->GetCachedList("bucket-a", "data/").has_value());
+	REQUIRE(context->GetCachedList("bucket-a", "data/year=2024/").has_value());
+	REQUIRE(context->GetCachedList("bucket-a", "other/").has_value());
+	REQUIRE(context->GetCachedList("bucket-b", "data/").has_value());
+
+	context->InvalidateCachedList("bucket-a");
+
+	// All listings for bucket-a are gone...
+	REQUIRE_FALSE(context->GetCachedList("bucket-a", "data/").has_value());
+	REQUIRE_FALSE(context->GetCachedList("bucket-a", "data/year=2024/").has_value());
+	REQUIRE_FALSE(context->GetCachedList("bucket-a", "other/").has_value());
+	// ...but the unrelated bucket is untouched.
+	REQUIRE(context->GetCachedList("bucket-b", "data/").has_value());
+}
+
+TEST_CASE("GCSContextState: InvalidateCachedList does not match bucket-name prefixes", "[gcs][directory][cache]") {
+	auto context = CreateTestContext();
+
+	vector<OpenFileInfo> results;
+	results.push_back(OpenFileInfo("gs://bucket/data/file.parquet"));
+
+	// "bucket" is a prefix of "bucket-2"; invalidating "bucket" must not evict "bucket-2".
+	context->SetCachedList("bucket", "data/", results);
+	context->SetCachedList("bucket-2", "data/", results);
+
+	context->InvalidateCachedList("bucket");
+
+	REQUIRE_FALSE(context->GetCachedList("bucket", "data/").has_value());
+	REQUIRE(context->GetCachedList("bucket-2", "data/").has_value());
+}
+
+TEST_CASE("GCSContextState: InvalidateCachedList on empty cache is a no-op", "[gcs][directory][cache]") {
+	auto context = CreateTestContext();
+	// Must not crash or throw when there is nothing cached.
+	context->InvalidateCachedList("bucket-a");
+	REQUIRE_FALSE(context->GetCachedList("bucket-a", "data/").has_value());
+}

--- a/test/sql/gcs_write.test
+++ b/test/sql/gcs_write.test
@@ -1,0 +1,29 @@
+# name: test/sql/gcs_write.test
+# description: Tests for writing files and directories (e.g. Hive partitioning) to GCS
+# group: [sql]
+
+require gcs
+
+require parquet
+
+# These tests run without credentials, so they exercise that the write/directory code paths are
+# wired up: they must fail with a credentials error rather than a "not implemented" error. Tests
+# that actually write to a bucket require authentication and are run manually (see test/README.md).
+
+# A plain directory write (PER_THREAD_OUTPUT) reaches DirectoryExists/CreateDirectory.
+statement error
+COPY (SELECT 1 AS a) TO 'gs://duckdb-gcs-testing/write_test_dir' (FORMAT parquet, PER_THREAD_OUTPUT true);
+----
+No valid GCP credentials found
+
+# A Hive-partitioned write also reaches the directory operations and must not be "not implemented".
+statement error
+COPY (SELECT 1 AS a, 'x' AS part) TO 'gs://duckdb-gcs-testing/write_test_parted' (FORMAT parquet, PARTITION_BY (part), OVERWRITE_OR_IGNORE);
+----
+No valid GCP credentials found
+
+# The gcss:// scheme (which forces this extension) must behave the same for partitioned writes.
+statement error
+COPY (SELECT 1 AS a, 'x' AS part) TO 'gcss://duckdb-gcs-testing/write_test_parted' (FORMAT parquet, PARTITION_BY (part), OVERWRITE_OR_IGNORE);
+----
+No valid GCP credentials found

--- a/test/sql/gcs_write_partitioned.test
+++ b/test/sql/gcs_write_partitioned.test
@@ -1,0 +1,105 @@
+# name: test/sql/gcs_write_partitioned.test
+# description: End-to-end write tests (single file, Hive partitioning, overwrite) against a real bucket
+# group: [sql]
+
+require gcs
+
+require parquet
+
+require-env GCS_AUTH_AVAILABLE
+
+# Bucket to write to. This must be a bucket you can write to, so it has no default: the test is
+# skipped unless GCS_TEST_WRITE_BUCKET is set, e.g.
+#   GCS_AUTH_AVAILABLE=1 GCS_TEST_WRITE_BUCKET=my-bucket build/release/test/unittest test/sql/gcs_write_partitioned.test
+require-env GCS_TEST_WRITE_BUCKET
+
+statement ok
+CREATE SECRET secret (TYPE gcp, PROVIDER credential_chain);
+
+# --- single file round-trip ---
+
+statement ok
+COPY (SELECT 1 AS a, 'x' AS b) TO 'gs://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/single.parquet' (FORMAT parquet);
+
+query II
+SELECT a, b FROM read_parquet('gs://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/single.parquet');
+----
+1	x
+
+# --- Hive-partitioned directory write ---
+
+statement ok
+COPY (SELECT * FROM (VALUES (1, 'x'), (2, 'x'), (3, 'y'), (4, 'z')) t(id, part))
+  TO 'gs://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/parted' (FORMAT parquet, PARTITION_BY (part), OVERWRITE);
+
+query II
+SELECT part, count(*) AS n
+FROM read_parquet('gs://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/parted/**/*.parquet', hive_partitioning = true)
+GROUP BY part ORDER BY part;
+----
+x	2
+y	1
+z	1
+
+# Writing without an overwrite option into the now non-empty directory must fail.
+statement error
+COPY (SELECT 9 AS id, 'q' AS part)
+  TO 'gs://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/parted' (FORMAT parquet, PARTITION_BY (part));
+----
+not empty
+
+# OVERWRITE must clear the previous partitions: rewriting with fewer partitions leaves only the new ones.
+statement ok
+COPY (SELECT * FROM (VALUES (10, 'm'), (11, 'n')) t(id, part))
+  TO 'gs://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/parted' (FORMAT parquet, PARTITION_BY (part), OVERWRITE);
+
+query II
+SELECT part, count(*) AS n
+FROM read_parquet('gs://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/parted/**/*.parquet', hive_partitioning = true)
+GROUP BY part ORDER BY part;
+----
+m	1
+n	1
+
+# --- multi-column partitioning ---
+
+statement ok
+COPY (SELECT * FROM (VALUES (1, 2024, 1), (2, 2024, 2), (3, 2025, 1)) t(id, year, month))
+  TO 'gs://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/multi' (FORMAT parquet, PARTITION_BY (year, month), OVERWRITE);
+
+query III
+SELECT year, month, count(*) AS n
+FROM read_parquet('gs://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/multi/**/*.parquet', hive_partitioning = true)
+GROUP BY year, month ORDER BY year, month;
+----
+2024	1	1
+2024	2	1
+2025	1	1
+
+# --- single-file overwrite via the gcss:// scheme (exercises MoveFile: gcss:// is not recognized as a
+#     remote path, so an existing target is written to a tmp file and then moved into place) ---
+
+statement ok
+COPY (SELECT 1 AS a) TO 'gcss://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/mv.parquet' (FORMAT parquet);
+
+statement ok
+COPY (SELECT 42 AS a) TO 'gcss://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/mv.parquet' (FORMAT parquet);
+
+query I
+SELECT a FROM read_parquet('gcss://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/mv.parquet');
+----
+42
+
+# --- partitioned write through the gcss:// scheme (takes the non-remote planning branch) ---
+
+statement ok
+COPY (SELECT * FROM (VALUES (1, 'x'), (2, 'y')) t(id, part))
+  TO 'gcss://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/parted_gcss' (FORMAT parquet, PARTITION_BY (part), OVERWRITE);
+
+query II
+SELECT part, count(*) AS n
+FROM read_parquet('gcss://${GCS_TEST_WRITE_BUCKET}/duckdb-gcs-write-test/parted_gcss/**/*.parquet', hive_partitioning = true)
+GROUP BY part ORDER BY part;
+----
+x	1
+y	1


### PR DESCRIPTION
The filesystem only implemented single-file read/write, so any directory-target write like `COPY … TO '<dir>' (… PARTITION_BY (…))` or `PER_THREAD_OUTPUT` failed with `GCSFileSystem: DirectoryExists is not implemented!`. DuckDB's COPY operator drives directory writes through `DirectoryExists` → `CreateDirectory`/`CheckDirectory` → `ListFiles` → `RemoveFiles`.

### Changes
Implements the directory/file write operations by mapping object-storage prefix semantics onto that contract:

- `DirectoryExists` true if any object shares the `key/` prefix (bucket root always true). Throws on a listing error rather than reporting "absent", so a partitioned `OVERWRITE` can't silently skip cleanup and mix old + new data.
- `CreateDirectory` / `CreateDirectoriesRecursive` no-ops (prefixes are implicit).
- `ListFilesExtended` delimiter-based listing of immediate children with `file`/`directory` types and relative names, mirroring the local FS; throws on error instead of yielding a partial listing.
- `RemoveFile` / `TryRemoveFile` / `RemoveFiles` / `RemoveDirectory` `DeleteObject`-based;
  `RemoveFiles` invalidates each affected bucket's list cache once rather than per file.
- `MoveFile` prefers the native server-side move (the `Objects: move` RPC) for same-bucket moves: an atomic metadata-only rename on Hierarchical-Namespace buckets, a single-call server-side move on flat buckets. Falls back to a server-side `RewriteObjectBlocking` + delete for cross-bucket moves or if the move RPC is unavailable. Covers the `gcss://` single-file overwrite path (which uses a tmp file).
- List-cache invalidation on writes/deletes so globs observe freshly written objects.

### Testing
I ran this against real buckets in both flat and Hierarchical-Namespace covering single file, Hive partitions, multi-column partitions, `PER_THREAD_OUTPUT`, `OVERWRITE` cleanup, and `gcss://` writes (including the native move).